### PR TITLE
Add GitHub action to provide the vcpkg precompiled archive

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/vcpkg-robotology/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows eigen3 libxml2 eigen3 matio ipopt-binary protobuf boost-math boost-asio boost-thread ace
+        C:/vcpkg-idjl/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows eigen3 libxml2 eigen3 matio ipopt-binary protobuf boost-math boost-asio boost-thread ace
         # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
         rm -rf C:/vcpkg-idjl/buildtrees 
         rm -rf C:/vcpkg-idjl/packages 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,11 +21,11 @@ jobs:
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/vcpkg-robotology/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows eigen3 libxml2 eigen3 matio ipopt-binary protobuf boost-math boost-asio boost-thread
+        C:/vcpkg-robotology/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows eigen3 libxml2 eigen3 matio ipopt-binary protobuf boost-math boost-asio boost-thread ace
         # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
-        rm -rf C:/vcpkg-robotology/buildtrees 
-        rm -rf C:/vcpkg-robotology/packages 
-        rm -rf C:/vcpkg-robotology/downloads 
+        rm -rf C:/vcpkg-idjl/buildtrees 
+        rm -rf C:/vcpkg-idjl/packages 
+        rm -rf C:/vcpkg-idjl/downloads 
         
     - uses: actions/upload-artifact@master
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    # We would like to build with v140 toolset to be compatible with both VS2017, 2019
+    # But that will only be avaiilable in late november: https://github.com/actions/virtual-environments/issues/68  
+    runs-on: windows-2019
+
+    steps:
+    - uses: actions/checkout@v1
+    
+    - name: Download custom vcpkg and additional ports 
+      shell: bash
+      run: |
+        git clone -b 2019.10 https://github.com/microsoft/vcpkg  C:/vcpkg-idjl
+        C:/vcpkg-robotology/bootstrap-vcpkg.sh
+        git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
+    - name: Install vcpkg ports
+      shell: bash
+      run: |
+        # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
+        C:/vcpkg-robotology/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows eigen3 libxml2 eigen3 matio ipopt-binary protobuf boost-math boost-asio boost-thread
+        # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
+        rm -rf C:/vcpkg-robotology/buildtrees 
+        rm -rf C:/vcpkg-robotology/packages 
+        rm -rf C:/vcpkg-robotology/downloads 
+        
+    - uses: actions/upload-artifact@master
+      with:
+        name: vcpkg-idjl
+        path: C:/vcpkg-idjl

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
       shell: bash
       run: |
         git clone -b 2019.10 https://github.com/microsoft/vcpkg  C:/vcpkg-idjl
-        C:/vcpkg-robotology/bootstrap-vcpkg.sh
+        C:/vcpkg-idjl/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
     - name: Install vcpkg ports
       shell: bash


### PR DESCRIPTION
Inspired to https://github.com/robotology-playground/robotology-superbuild-dependencies .
The `.zip` archive is automatically updated to the artifacts tab, and then it can be uploaded to the release page as done in https://github.com/robotology-playground/robotology-superbuild-dependencies/releases .