### PR TITLE
Add ensenso-binary port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/idjl/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows eigen3 libxml2 eigen3 matio ipopt-binary protobuf asio ace pcl
+        C:/idjl/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary protobuf asio ace pcl
         # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
         rm -rf C:/idjl/vcpkg/buildtrees 
         rm -rf C:/idjl/vcpkg/packages 


### PR DESCRIPTION
To compile against software that uses ensenso. 
See https://github.com/robotology/robotology-vcpkg-binary-ports/pull/6 for a related PR.
After this PR, we  can do a new release that includes the ensenso binaries.