### PR TITLE
Add use of upload-release-asset GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+  pull_request:
+  release:
+    types: [published]
 
 jobs:
   build:
@@ -37,3 +41,20 @@ jobs:
       with:
         name: vcpkg-idjl
         path: C:/idjl/vcpkg
+        
+    - name: Prepare release file
+      if: github.event_name == 'release'
+      shell: cmd 
+      run: |
+        7z a vcpkg-idjl.zip C:\idjl
+        
+    - name: Upload Release Asset
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./vcpkg-idjl.zip
+          asset_name: vcpkg-idjl.zip
+          asset_content_type: application/zip


### PR DESCRIPTION
Via this GitHub Action, it is possible to automatically upload the archive that contains the generate vcpkg archive. 

See https://github.com/actions/upload-release-asset/issues/34 for details.