### PR TITLE
Add workaround for bug in VS2019 16.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Remove faulty VS2019 16.5
       shell: bash
       run: |
-        rm -rf "${ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610"
+        rm -rf "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610"
 
     - name: Install vcpkg ports
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,12 @@ jobs:
       run: |
         df -h
     
+    # Workaround for https://github.com/actions/virtual-environments/issues/605
+    - name: Remove faulty VS2019 16.5
+      shell: powershell
+      run: |
+        Remove-Item -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610" -Force -Recurse
+    
     - name: Download custom vcpkg and additional ports 
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,7 @@ jobs:
     - name: Remove faulty VS2019 16.5
       shell: powershell
       run: |
+        Start-Sleep 5
         Remove-Item -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610" -Force -Recurse
 
     - name: Install vcpkg ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,7 @@ jobs:
       shell: bash 
       run: |
         df -h
-    
-    # Workaround for https://github.com/actions/virtual-environments/issues/605
-    - name: Remove faulty VS2019 16.5
-      shell: powershell
-      run: |
-        Remove-Item -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610" -Force -Recurse
-    
+
     - name: Download custom vcpkg and additional ports 
       shell: bash
       run: |
@@ -33,6 +27,13 @@ jobs:
         git clone -b 2020.01 https://github.com/microsoft/vcpkg  C:/idjl/vcpkg
         C:/idjl/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
+        
+    # Workaround for https://github.com/actions/virtual-environments/issues/605
+    - name: Remove faulty VS2019 16.5
+      shell: powershell
+      run: |
+        Remove-Item -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610" -Force -Recurse
+
     - name: Install vcpkg ports
       shell: bash
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,9 @@ jobs:
         
     # Workaround for https://github.com/actions/virtual-environments/issues/605
     - name: Remove faulty VS2019 16.5
-      shell: powershell
+      shell: bash
       run: |
-        Start-Sleep 60
-        Remove-Item -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610" -Force -Recurse
+        rm -rf "${ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610"
 
     - name: Install vcpkg ports
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
     - name: Remove faulty VS2019 16.5
       shell: powershell
       run: |
-        Start-Sleep 5
+        Start-Sleep 60
         Remove-Item -Path "${env:ProgramFiles(x86)}\Microsoft Visual Studio\2019\Enterprise\VC\Tools\MSVC\14.25.28610" -Force -Recurse
 
     - name: Install vcpkg ports


### PR DESCRIPTION
See the  discussion in https://github.com/actions/virtual-environments/issues/605 for more info. 
Unfortunatly, this is necessary now to actually compile the pre-compiled vcpkg archive. 