### PR TITLE
Fix token used to upload releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,7 +58,7 @@ jobs:
       if: github.event_name == 'release'
       uses: actions/upload-release-asset@v1.0.1
       env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
       with:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./vcpkg-idjl.zip


### PR DESCRIPTION
The GitHub Action to upload release assets added  in https://github.com/iit-danieli-joint-lab/idjl-software-dependencies-vcpkg/pull/7 to automatically upload archive in releases was working correctly on small test releases, but it was failing with the error: 
~~~
##[error]Bad credentials
~~~
on the actual release workflow, that was taking more then 4 hours to complete (see for example: https://github.com/iit-danieli-joint-lab/idjl-software-dependencies-vcpkg/runs/529920938?check_suite_focus=true). It turns out that the problem here is that the automatically generated `GITHUB_TOKEN` secret expires after 1 hour:

> The installation access token expires after 60 minutes. GitHub fetches a token for each job, before the job begins.
>
> Note: When a workflow run or its jobs are queued for more than one hour, the token may expire before the job starts.

See https://help.github.com/en/actions/configuring-and-managing-workflows/authenticating-with-the-github_token#about-the-github_token-secret . 

For this reason, despite the examples provided in https://github.com/actions/upload-release-asset use `GITHUB_TOKEN`, for long  jobs it make sense to use a proper generated token (see https://help.github.com/en/enterprise/2.17/user/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line).  In this case, I already added  a new personal token with the proper permissions in the [secrets](https://help.github.com/en/actions/configuring-and-managing-workflows/creating-and-storing-encrypted-secrets) of this repo under the name `ACCESS_TOKEN`, and this PR makes use of it. 