### PR TITLE
Remove downloaded archive from C:/idjl

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,7 @@ jobs:
         # Download a custom vcpkg 2020.01 that already contains ace pre-compiled, as a workaround for https://github.com/actions/virtual-environments/issues/605
         wget https://github.com/iit-danieli-joint-lab/idjl-software-dependencies-vcpkg/releases/download/temporary-storage/idjl-vcpkg-2020.01-ace.zip
         7z x idjl-vcpkg-2020.01-ace.zip
+        rm idjl-vcpkg-2020.01-ace.zip
         C:/idjl/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
         


### PR DESCRIPTION
Otherwise, it remains in `C:/idjl` and is then included in the released archive.