### PR TITLE
Add support to include Gazebo in  idjl-software-dependencies-vcpkg

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,10 @@ jobs:
       shell: bash 
       run: |
         df -h
+  
+    # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
+    - name: Override bash shell PATH (windows-latest)
+      run: echo "::add-path::C:\Program Files\Git\bin"
     
     - name: Download custom vcpkg and additional ports 
       shell: bash
@@ -30,24 +34,49 @@ jobs:
         wget https://github.com/iit-danieli-joint-lab/idjl-software-dependencies-vcpkg/releases/download/temporary-storage/idjl-vcpkg-2020.01-ace.zip
         7z x idjl-vcpkg-2020.01-ace.zip
         rm idjl-vcpkg-2020.01-ace.zip
+        cd C:/idjl/vcpkg
+        # Update vcpkg to a newer commit
+        git fetch
+        git checkout 5852144908b2c714be6f0d343f1de01ca2ec7758
         C:/idjl/vcpkg/bootstrap-vcpkg.sh
-        git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/robotology-vcpkg-binary-ports
-        
+        git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/idjl/robotology-vcpkg-binary-ports
+        cd C:/idjl/robotology-vcpkg-binary-ports
+        git checkout v0.1.0        
         
     - name: Install vcpkg ports
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/idjl/vcpkg/vcpkg.exe --overlay-ports=C:/robotology-vcpkg-binary-ports install --triplet x64-windows assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary protobuf asio ace pcl winpcap
-        # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
-        rm -rf C:/idjl/vcpkg/buildtrees 
-        rm -rf C:/idjl/vcpkg/packages 
-        rm -rf C:/idjl/vcpkg/downloads 
+        C:/idjl/vcpkg/vcpkg.exe --overlay-ports=C:/idjl/robotology-vcpkg-binary-ports install --triplet x64-windows assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary protobuf asio ace pcl winpcap
+
+    # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
+    # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 
+    # See https://github.com/microsoft/vcpkg/issues/10365  
+    - name: Cleanup vcpkg temporary directories
+      shell: cmd 
+      run: |
+        RMDIR /Q/S C:\idjl\vcpkg\buildtrees
+        RMDIR /Q/S C:\idjl\vcpkg\packages
+        RMDIR /Q/S C:\idjl\vcpkg\downloads
+
+    - name: Install setup scripts    
+      shell: bash
+      run: |
+        mkdir /c/idjl/scripts
+        cp scripts/setup-vcpkg.bat /c/idjl/scripts
+        cp scripts/setup-deps.bat /c/idjl/scripts
+        cp scripts/setup-vcpkg.sh /c/idjl/scripts
+        cp scripts/setup-deps.sh /c/idjl/scripts
+        cp scripts/addPathsToUserEnvVariables-vcpkg.ps1 /c/idjl/scripts
+        cp scripts/addPathsToUserEnvVariables-deps.ps1 /c/idjl/scripts
+        cp scripts/removePathsFromUserEnvVariables-vcpkg.ps1 /c/idjl/scripts
+        cp scripts/removePathsFromUserEnvVariables-deps.ps1 /c/idjl/scripts
+
         
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v1
       with:
         name: vcpkg-idjl
-        path: C:/idjl/vcpkg
+        path: C:/idjl
         
     - name: Prepare release file
       if: github.event_name == 'release'
@@ -64,4 +93,111 @@ jobs:
           upload_url: ${{ github.event.release.upload_url }}
           asset_path: ./vcpkg-idjl.zip
           asset_name: vcpkg-idjl.zip
+          asset_content_type: application/zip
+
+  build-with-gazebo-deps:
+    runs-on: windows-2019
+    needs: build
+
+    steps:
+    - uses: actions/checkout@v1
+
+    - uses: actions/download-artifact@v1
+      with:
+        name: vcpkg-idjl
+        path: C:/idjl
+
+    - name: Check free space 
+      shell: bash 
+      run: |
+        df -h
+    
+    - name: Install vcpkg ports
+      shell: bash
+      run: |
+        # Install dependencies for gazebo11 and related ignition dependencies (listed in https://github.com/ignition-tooling/gazebodistro/blob/master/gazebo11.yaml)         
+        # gts is not present due to https://github.com/microsoft/vcpkg/issues/10422, and its dependency glib is present instead
+        C:/idjl/vcpkg/vcpkg.exe --overlay-ports=C:/idjl/robotology-vcpkg-binary-ports install --triplet x64-windows boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage glib libyaml libzip jsoncpp ogre protobuf qt5-base[latest] qwt sqlite3[core,tool] tbb tinyxml tinyxml2 urdfdom zeromq
+        
+    # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
+    # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 
+    # See https://github.com/microsoft/vcpkg/issues/10365  
+    - name: Cleanup vcpkg temporary directories
+      shell: cmd 
+      run: |
+        RMDIR /Q/S C:\idjl\vcpkg\buildtrees
+        RMDIR /Q/S C:\idjl\vcpkg\packages
+        RMDIR /Q/S C:\idjl\vcpkg\downloads
+        
+    - uses: actions/upload-artifact@v1
+      with:
+        name: vcpkg-idjl-with-gazebo-deps
+        path: C:/idjl
+
+  build-with-gazebo:
+    runs-on: windows-2019
+    needs: build-with-gazebo-deps
+
+    steps:
+    - uses: actions/checkout@v1
+  
+    - uses: actions/download-artifact@v1
+      with:
+        name: vcpkg-idjl-with-gazebo-deps
+        path: C:/idjl
+    
+    - name: Check free space 
+      shell: bash 
+      run: |
+        df -h
+        
+    - name: Install required python-based tools
+      shell: bash
+      run: |
+        pip install vcstool colcon-common-extensions
+    
+    # Based on https://colcon.readthedocs.io/en/released/user/quick-start.html#build-gazebo-and-the-ignition-packages
+    - name: Download Gazebo and related libraries
+      shell: bash
+      run: |
+        mkdir C:/idjl/gazebo
+        cd C:/idjl/gazebo
+        mkdir src
+        vcs import src < ${GITHUB_WORKSPACE}/gazebo-repos.yaml
+        
+    - name: Build Gazebo and related libraries
+      shell: bash
+      run: |
+        cd C:/idjl/gazebo
+        colcon build --merge-install --cmake-args -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/idjl/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_TESTING:BOOL=OFF        
+    # Remove temporary files
+    - name: Cleanup vcpkg temporary directories
+      shell: cmd 
+      run: |
+        RMDIR /Q/S C:\idjl\gazebo\build
+        RMDIR /Q/S C:\idjl\gazebo\src
+        
+    - name: Install setup scripts    
+      shell: bash
+      run: |
+        cp scripts/setup-gazebo.bat /c/idjl/scripts
+        cp scripts/setup-gazebo.sh /c/idjl/scripts
+        cp scripts/addPathsToUserEnvVariables-gazebo.ps1 /c/idjl/scripts
+        cp scripts/removePathsFromUserEnvVariables-gazebo.ps1 /c/idjl/scripts
+        
+    - name: Prepare release file
+      if: github.event_name == 'release'
+      shell: cmd 
+      run: |
+        7z a vcpkg-idjl-with-gazebo.zip C:\idjl
+        
+    - name: Upload Release Asset
+      if: github.event_name == 'release'
+      uses: actions/upload-release-asset@v1.0.1
+      env:
+        GITHUB_TOKEN: ${{ secrets.ACCESS_TOKEN }}
+      with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: ./vcpkg-idjl-with-gazebo.zip
+          asset_name: vcpkg-idjl-with-gazebo.zip
           asset_content_type: application/zip

--- a/gazebo-repos.yaml
+++ b/gazebo-repos.yaml
@@ -1,0 +1,37 @@
+repositories:
+  gazebo:
+    type: git
+    url: https://github.com/traversaro/gazebo
+    version: 4ada2574f0735f6fdc933b6bc7e104b00e50e25e
+  gts:
+    type: git
+    url: https://github.com/finetjul/gts
+    version: c4da61ae075f355d9ecc9f2d4767acf777f54c2b
+  ign-cmake:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-cmake
+    version: 2f5c3178dbee496beedf8e4a636a2c71219fe8e0
+  ign-common:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-common
+    version: 70658d137256dd57e87690ff45bd3c077c087f09
+  ign-fuel-tools:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-fuel-tools
+    version: af1eec41c92cdc9b26b9d03b084b7aeb3ca1fb9e
+  ign-math:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-math
+    version: c2726425418f93a0ea384815c7eab55749a7d0ea
+  ign-msgs:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-msgs
+    version: 84ff940249ce23a62917d8ca239f79450548d0a0
+  ign-transport:
+    type: git
+    url: https://github.com/ignitionrobotics/ign-transport
+    version: 185edc9ce3c5254b1b57aa4b87af5f6c474ce097
+  sdformat:
+    type: git
+    url: https://github.com/osrf/sdformat
+    version: f7dcdd74fb900e79d5d12db4e022f6e9c83831a1

--- a/scripts/addPathsToUserEnvVariables-deps.ps1
+++ b/scripts/addPathsToUserEnvVariables-deps.ps1
@@ -1,0 +1,13 @@
+$installerRootPath = (Split-Path -parent (Split-Path -Path $PSCommandPath));
+
+# Call the script to update the env variables of vcpkg 
+$vcpkgTriplet = 'x64-windows';
+$vcpkgScript = $installerRootPath + '\scripts\addPathsToUserEnvVariables-vcpkg.ps1'
+Invoke-Expression $vcpkgScript
+
+# Call the script to update the env variables of gazebo 
+$gazeboScript = $installerRootPath + '\scripts\addPathsToUserEnvVariables-gazebo.ps1'
+
+if ((Test-Path $gazeboScript)) {
+  Invoke-Expression $gazeboScript
+}

--- a/scripts/addPathsToUserEnvVariables-gazebo.ps1
+++ b/scripts/addPathsToUserEnvVariables-gazebo.ps1
@@ -1,0 +1,42 @@
+# Set a value to a given "User" enviromental variable
+function Set-ValueToUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Set ' $Value ' to the ' $EnvVariable ' User enviroment variable.'
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $Value, 'User');
+}
+
+# Add a value to a given "User" enviromental variable
+function Add-ValueToUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Appending ' $Value ' to the ' $EnvVariable ' User enviroment variable.'
+  }
+  $currVar = [System.Environment]::GetEnvironmentVariable($EnvVariable, 'User');
+  # If the enviromental variable is currently empty, do not add an initial ";"
+  if ([string]::IsNullOrEmpty($currVar)) {
+    $newVar = $Value;
+  } else {
+    $newVar = $currVar + ';' + $Value;
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $newVar, 'User');
+}
+
+$parentPath = Split-Path -Path $PSCommandPath;
+$vcpkgTriplet = 'x64-windows';
+$vcpkgInstallDir = (Split-Path -parent $parentPath) + '\vcpkg\installed\' + $vcpkgTriplet;
+
+$gazeboInstallDir = (Split-Path -parent $parentPath) + '\gazebo\install';
+$gazeboMajorVersion = '11';
+
+# This logic mimics part of the logic contained in share\gazebo\setup.bat 
+Set-ValueToUserEnvVariable HOME ($env:HOMEDRIVE + $env:HOMEPATH);
+Set-ValueToUserEnvVariable GAZEBO_MASTER_URI 'http://localhost:11345'
+Set-ValueToUserEnvVariable GAZEBO_MODEL_DATABASE_URI 'http://models.gazebosim.org'
+Add-ValueToUserEnvVariable GAZEBO_RESOURCE_PATH ($gazeboInstallDir + '\share\gazebo-' + $gazeboMajorVersion);
+Add-ValueToUserEnvVariable GAZEBO_PLUGIN_PATH ($gazeboInstallDir + '\bin\gazebo-' + $gazeboMajorVersion + '\plugins');
+Add-ValueToUserEnvVariable GAZEBO_MODEL_PATH ($gazeboInstallDir + '\share\gazebo-' + $gazeboMajorVersion + '\models');
+Add-ValueToUserEnvVariable PATH ($gazeboInstallDir + '\bin\gazebo-' + $gazeboMajorVersion + '\plugins');
+Set-ValueToUserEnvVariable OGRE_RESOURCE_PATH ($vcpkgInstallDir + '\bin');
+
+# Also add the bin to the path directly (not present in share\gazebo\setup.bat)
+Add-ValueToUserEnvVariable PATH ($gazeboInstallDir + "\bin");

--- a/scripts/addPathsToUserEnvVariables-vcpkg.ps1
+++ b/scripts/addPathsToUserEnvVariables-vcpkg.ps1
@@ -1,0 +1,42 @@
+# Set a value to a given "User" enviromental variable
+function Set-ValueToUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Set ' $Value ' to the ' $EnvVariable ' User enviroment variable.'
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $Value, 'User');
+}
+
+# Add a value to a given "User" enviromental variable
+function Add-ValueToUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Appending ' $Value ' to the ' $EnvVariable ' User enviroment variable.'
+  }
+  $currVar = [System.Environment]::GetEnvironmentVariable($EnvVariable, 'User');
+  # If the enviromental variable is currently empty, do not add an initial ";"
+  if ([string]::IsNullOrEmpty($currVar)) {
+    $newVar = $Value;
+  } else {
+    $newVar = $currVar + ';' + $Value;
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $newVar, 'User');
+}
+
+$parentPath = Split-Path -Path $PSCommandPath;
+$vcpkgTriplet = 'x64-windows';
+$vcpkgInstallDir = (Split-Path -parent $parentPath) + '\vcpkg\installed\' + $vcpkgTriplet;
+
+# This logic mimics part of the logic contained in vcpkg\scripts\buildsystems\vcpkg.cmake
+# to user enviroment variables. It has been tested only for a limited amount of vcpkg ports,
+# and it is not officially maintained by the vcpkg team. To make sure that a dependency is correctly 
+# found by CMake, use the official CMake vcpkg toolchain as documented in vcpkg docs.
+
+# Extend PATH
+Add-ValueToUserEnvVariable PATH ($VcpkgInstallDir + "\bin");
+Add-ValueToUserEnvVariable PATH ($VcpkgInstallDir + "\debug\bin");
+
+# Extend CMAKE_PREFIX_PATH
+Add-ValueToUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir);
+Add-ValueToUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir + "\debug");
+
+# Extend CMAKE_PROGRAM_TOOLS (for protobuf)
+Add-ValueToUserEnvVariable CMAKE_PROGRAM_PATH ($VcpkgInstallDir + "\tools\protobuf");

--- a/scripts/removePathsFromUserEnvVariables-deps.ps1
+++ b/scripts/removePathsFromUserEnvVariables-deps.ps1
@@ -1,0 +1,12 @@
+$installerRootPath = (Split-Path -parent (Split-Path -Path $PSCommandPath));
+
+# Call the script to cleanup the env variables of vcpkg 
+$vcpkgTriplet = 'x64-windows';
+$vcpkgScript = $installerRootPath + '\scripts\removePathsFromUserEnvVariables-vcpkg.ps1'
+Invoke-Expression $vcpkgScript
+
+# Call the script to cleanup the env variables of gazebo 
+$gazeboScript = $installerRootPath + '\scripts\removePathsFromUserEnvVariables-gazebo.ps1'
+if ((Test-Path $gazeboScript)) {
+  Invoke-Expression $gazeboScript
+}

--- a/scripts/removePathsFromUserEnvVariables-gazebo.ps1
+++ b/scripts/removePathsFromUserEnvVariables-gazebo.ps1
@@ -1,0 +1,45 @@
+# Remove a given "User" enviromental variable
+function Remove-UserEnvVariable ($EnvVariable, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Removing ' $EnvVariable ' User enviroment variable.'
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $null, 'User');
+}
+
+# Remove a value from a given "User" enviromental variable
+function Remove-ValueFromUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Removing ' $Value ' from the ' $EnvVariable ' User enviroment variable.'
+  }
+  $currVar = [System.Environment]::GetEnvironmentVariable($EnvVariable, 'User');
+  # If the env variable is already empty, do not do anything
+  if (-Not [string]::IsNullOrEmpty($currVar)) {
+    $newVar = ($currVar.Split(';') | Where-Object { $_ -ne $Value }) -join ';';
+    # If the resulting final variable is empty, delete the enviromental variable
+    if ([string]::IsNullOrEmpty($newVar)) {
+      [System.Environment]::SetEnvironmentVariable($EnvVariable, $null, 'User');
+    } else {
+      [System.Environment]::SetEnvironmentVariable($EnvVariable, $newVar, 'User');
+    }
+  }
+}
+
+$parentPath = Split-Path -Path $PSCommandPath;
+$vcpkgTriplet = 'x64-windows';
+$vcpkgInstallDir = (Split-Path -parent $parentPath) + '\vcpkg\installed\' + $vcpkgTriplet;
+
+$gazeboInstallDir = (Split-Path -parent $parentPath) + '\gazebo\install';
+$gazeboMajorVersion = '11';
+
+# This logic mimics part of the logic contained in share\gazebo\setup.bat 
+Remove-UserEnvVariable HOME;
+Remove-UserEnvVariable GAZEBO_MASTER_URI;
+Remove-UserEnvVariable GAZEBO_MODEL_DATABASE_URI;
+Remove-ValueFromUserEnvVariable GAZEBO_RESOURCE_PATH ($gazeboInstallDir + '\share\gazebo-' + $gazeboMajorVersion);
+Remove-ValueFromUserEnvVariable GAZEBO_PLUGIN_PATH ($gazeboInstallDir + '\bin\gazebo-' + $gazeboMajorVersion + '\plugins');
+Remove-ValueFromUserEnvVariable GAZEBO_MODEL_PATH ($gazeboInstallDir + '\share\gazebo-' + $gazeboMajorVersion + '\models');
+Remove-ValueFromUserEnvVariable PATH ($gazeboInstallDir + '\bin\gazebo-' + $gazeboMajorVersion + '\plugins');
+Remove-UserEnvVariable OGRE_RESOURCE_PATH;
+
+# Also add the bin to the path directly (not present in share\gazebo\setup.bat)
+Remove-ValueFromUserEnvVariable PATH ($gazeboInstallDir + "\bin");

--- a/scripts/removePathsFromUserEnvVariables-vcpkg.ps1
+++ b/scripts/removePathsFromUserEnvVariables-vcpkg.ps1
@@ -1,0 +1,41 @@
+# Remove a given "User" enviromental variable
+function Remove-UserEnvVariable ($EnvVariable, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Removing ' $EnvVariable ' User enviroment variable.'
+  }
+  [System.Environment]::SetEnvironmentVariable($EnvVariable, $null, 'User');
+}
+
+# Remove a value from a given "User" enviromental variable
+function Remove-ValueFromUserEnvVariable ($EnvVariable, $Value, $Verbose=$TRUE) {
+  if ($Verbose) {
+    Write-Host 'Removing ' $Value ' from the ' $EnvVariable ' User enviroment variable.'
+  }
+  $currVar = [System.Environment]::GetEnvironmentVariable($EnvVariable, 'User');
+  # If the env variable is already empty, do not do anything
+  if (-Not [string]::IsNullOrEmpty($currVar)) {
+    $newVar = ($currVar.Split(';') | Where-Object { $_ -ne $Value }) -join ';';
+    # If the resulting final variable is empty, delete the enviromental variable
+    if ([string]::IsNullOrEmpty($newVar)) {
+      [System.Environment]::SetEnvironmentVariable($EnvVariable, $null, 'User');
+    } else {
+      [System.Environment]::SetEnvironmentVariable($EnvVariable, $newVar, 'User');
+    }
+  }
+}
+
+$parentPath = Split-Path -Path $PSCommandPath;
+$vcpkgTriplet = 'x64-windows';
+$vcpkgInstallDir = (Split-Path -parent $parentPath) + '\vcpkg\installed\' + $vcpkgTriplet;
+
+# Cleanup PATH
+Remove-ValueFromUserEnvVariable PATH ($VcpkgInstallDir + "\bin");
+Remove-ValueFromUserEnvVariable PATH ($VcpkgInstallDir + "\debug\bin");
+
+# Cleanup CMAKE_PREFIX_PATH
+Remove-ValueFromUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir);
+Remove-ValueFromUserEnvVariable CMAKE_PREFIX_PATH ($VcpkgInstallDir + "\debug");
+
+# Cleanup CMAKE_PROGRAM_PATH
+Remove-ValueFromUserEnvVariable CMAKE_PROGRAM_PATH ($VcpkgInstallDir + "\tools\protobuf");
+

--- a/scripts/setup-deps.bat
+++ b/scripts/setup-deps.bat
@@ -1,0 +1,12 @@
+@echo off
+
+pushd %~dp0..
+set installerRootPath=%cd%
+popd
+
+rem Call vcpkg script
+call %installerRootPath%\scripts\setup-vcpkg.bat 
+
+rem Call gazebo script (if it exists)
+set gazeboScript=%installerRootPath%\scripts\setup-gazebo.bat 
+if exist %gazeboScript% call %gazeboScript% 

--- a/scripts/setup-deps.sh
+++ b/scripts/setup-deps.sh
@@ -1,0 +1,11 @@
+scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
+installerRootPath=`realpath $scriptDirectory/..`
+
+# Source vcpkg script 
+source $installerRootPath/scripts/setup-vcpkg.sh
+
+# Source gazebo script (if it exists)
+gazeboScript=$installerRootPath/scripts/setup-gazebo.sh
+if test -f "$gazeboScript"; then
+    source $gazeboScript
+fi

--- a/scripts/setup-gazebo.bat
+++ b/scripts/setup-gazebo.bat
@@ -1,0 +1,9 @@
+@echo off
+
+pushd %~dp0..
+set installerRootPath=%cd%
+popd
+
+
+set "PATH=%PATH%;%installerRootPath%\gazebo\install\bin"
+call %installerRootPath%\gazebo\install\share\gazebo\setup.bat

--- a/scripts/setup-gazebo.sh
+++ b/scripts/setup-gazebo.sh
@@ -1,0 +1,22 @@
+scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
+installerRootPath=`realpath $scriptDirectory/..`
+gazeboInstallDir=$installerRootPath/gazebo/install
+gazeboMajorVersion="11"
+
+vcpkgTriplet="x64-windows"
+vcpkgInstallDir=${installerRootPath}/vcpkg/installed/${vcpkgTriplet}
+
+export PATH=$PATH:$gazeboInstallDir/bin
+
+export GAZEBO_MASTER_URI=http://localhost:11345
+export GAZEBO_MODEL_DATABASE_URI=http://models.gazebosim.org
+# https://unix.stackexchange.com/questions/162891/append-to-path-like-variable-without-creating-leading-colon-if-unset
+export GAZEBO_RESOURCE_PATH=${GAZEBO_RESOURCE_PATH:+${GAZEBO_RESOURCE_PATH}:}${gazeboInstallDir}/share/gazebo-${gazeboMajorVersion}
+export GAZEBO_PLUGIN_PATH=${GAZEBO_PLUGIN_PATH:+${GAZEBO_PLUGIN_PATH}:}${gazeboInstallDir}/bin/gazebo-${gazeboMajorVersion}/plugins
+export GAZEBO_MODEL_PATH=${GAZEBO_MODEL_PATH:+${GAZEBO_MODEL_PATH}:}${gazeboInstallDir}/share/gazebo-${gazeboMajorVersion}/models
+export PATH=$PATH:${gazeboInstallDir}/bin/gazebo-${gazeboMajorVersion}/plugins
+export OGRE_RESOURCE_PATH=${vcpkgInstallDir}/bin
+
+
+
+

--- a/scripts/setup-vcpkg.bat
+++ b/scripts/setup-vcpkg.bat
@@ -1,0 +1,19 @@
+@echo off
+
+pushd %~dp0..
+set "installerRootPath=%cd%"
+popd
+
+set "vcpkgTriplet=x64-windows"
+set "vcpkgInstallDir=%installerRootPath%\vcpkg\installed\%vcpkgTriplet%"
+
+rem Update PATH 
+set "PATH=%PATH%;%vcpkgInstallDir%\bin"
+set "PATH=%PATH%;%vcpkgInstallDir%\debug\bin"
+
+rem Update CMAKE_PREFIX_PATH
+set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%vcpkgInstallDir%"
+set "CMAKE_PREFIX_PATH=%CMAKE_PREFIX_PATH%;%vcpkgInstallDir%\debug"
+
+rem Update CMAKE_PROGRAM_PATH
+set "CMAKE_PROGRAM_PATH=%CMAKE_PROGRAM_PATH%;%vcpkgInstallDir%\tools\protobuf"

--- a/scripts/setup-vcpkg.sh
+++ b/scripts/setup-vcpkg.sh
@@ -1,0 +1,18 @@
+scriptDirectory="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )" 
+installerRootPath=`realpath $scriptDirectory/..`
+
+vcpkgTriplet="x64-windows"
+vcpkgInstallDir=${installerRootPath}/vcpkg/installed/${vcpkgTriplet}
+
+# Update PATH 
+export PATH=$PATH:${vcpkgInstallDir}/bin
+export PATH=$PATH:${vcpkgInstallDir}/debug/bin
+
+# See https://unix.stackexchange.com/questions/162891/append-to-path-like-variable-without-creating-leading-colon-if-unset
+
+# Update CMAKE_PREFIX_PATH
+export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+${CMAKE_PREFIX_PATH}:}${vcpkgInstallDir}
+export CMAKE_PREFIX_PATH=${CMAKE_PREFIX_PATH:+${CMAKE_PREFIX_PATH}:}${vcpkgInstallDir}/debug
+
+# Update CMAKE_PROGRAM_TOOLS (for protobuf)
+export CMAKE_PROGRAM_PATH=${CMAKE_PROGRAM_PATH:+${CMAKE_PROGRAM_PATH}:}${vcpkgInstallDir}/tools/protobuf


### PR DESCRIPTION
On the top of the usual `vcpkg-idjl.zip` archive, this commit also generates the archive `vcpkg-idjl-with-gazebo.zip`, that is like the usual `vcpkg-idjl.zip` archive, but that also contains a `C:\idjl\gazebo\install` directory in which gazebo 11 and its dependencies are installed.

As Gazebo in this case it is  not installed via vcpkg, it is not possible to find it via the official vcpkg's integration via the `CMAKE_TOOLCHAIN_FILE`, so also a set of scripts is provided to set for a given terminal (`setup-deps.bat` and `setup-deps.sh`) or for the system (`addPathsToUserEnvVariables-deps.ps1` and `removePathsFromUserEnvVariables-deps.ps1`) the necessary environment variables to find the dependencies and run Gazebo.

The specific version of Gazebo installed by the scripts are contained in the gazebo-repos.yaml file. They do refer to specific commit due to the fact that the Gazebo windows support requires some of the latest fix (some still pending, see https://github.com/osrf/gazebo/pull/2719), but they will be updated to tags once a release will be made including the required tags.

Similar to the PR https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/pull/17 .