### PR TITLE
Update vcpkg dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-binary-ports install --triplet x64-windows assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary libpcap protobuf asio ace pcl
+        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-binary-ports install --triplet x64-windows assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary libpcap protobuf asio ace pcl yaml-cpp
 
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
     # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,8 @@ jobs:
         cd C:/idjl-deps/vcpkg
         # Update vcpkg to a newer commit
         git fetch
-        git checkout 5852144908b2c714be6f0d343f1de01ca2ec7758
+        # vcpkg commit of 2020/06/12
+        git checkout 250e35a961f6faea691e2266613e671a61bb3ab6
         C:/idjl-deps/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/idjl-deps/robotology-vcpkg-binary-ports
         cd C:/idjl-deps/robotology-vcpkg-binary-ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,14 @@ jobs:
       run: |
         cd C:/idjl-deps/gazebo
         colcon build --merge-install --cmake-args -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/idjl-deps/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_TESTING:BOOL=OFF        
+    
+    - name: On failure upload build logs for debug
+      if: ${{ failure() }}
+      uses: actions/upload-artifact@v1
+      with:
+        name: vcpkg-gazebo-build-logs
+        path: C:/idjl-deps/gazebo/log
+    
     # Remove temporary files
     - name: Cleanup colcon temporary directories
       shell: cmd 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-binary-ports install --triplet x64-windows assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary protobuf asio ace pcl winpcap
+        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-binary-ports install --triplet x64-windows assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary libpcap protobuf asio ace pcl
 
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
     # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,26 +28,26 @@ jobs:
       shell: bash
       run: |
         choco install -y wget
-        mkdir C:/idjl
-        cd C:/idjl
+        mkdir C:/idjl-deps
+        cd C:/idjl-deps
         # Download a custom vcpkg 2020.01 that already contains ace pre-compiled, as a workaround for https://github.com/actions/virtual-environments/issues/605
         wget https://github.com/iit-danieli-joint-lab/idjl-software-dependencies-vcpkg/releases/download/temporary-storage/idjl-vcpkg-2020.01-ace.zip
         7z x idjl-vcpkg-2020.01-ace.zip
         rm idjl-vcpkg-2020.01-ace.zip
-        cd C:/idjl/vcpkg
+        cd C:/idjl-deps/vcpkg
         # Update vcpkg to a newer commit
         git fetch
         git checkout 5852144908b2c714be6f0d343f1de01ca2ec7758
-        C:/idjl/vcpkg/bootstrap-vcpkg.sh
-        git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/idjl/robotology-vcpkg-binary-ports
-        cd C:/idjl/robotology-vcpkg-binary-ports
+        C:/idjl-deps/vcpkg/bootstrap-vcpkg.sh
+        git clone https://github.com/robotology-dependencies/robotology-vcpkg-binary-ports C:/idjl-deps/robotology-vcpkg-binary-ports
+        cd C:/idjl-deps/robotology-vcpkg-binary-ports
         git checkout v0.1.0        
         
     - name: Install vcpkg ports
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/idjl/vcpkg/vcpkg.exe --overlay-ports=C:/idjl/robotology-vcpkg-binary-ports install --triplet x64-windows assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary protobuf asio ace pcl winpcap
+        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-binary-ports install --triplet x64-windows assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary protobuf asio ace pcl winpcap
 
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
     # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 
@@ -55,34 +55,34 @@ jobs:
     - name: Cleanup vcpkg temporary directories
       shell: cmd 
       run: |
-        RMDIR /Q/S C:\idjl\vcpkg\buildtrees
-        RMDIR /Q/S C:\idjl\vcpkg\packages
-        RMDIR /Q/S C:\idjl\vcpkg\downloads
+        RMDIR /Q/S C:\idjl-deps\vcpkg\buildtrees
+        RMDIR /Q/S C:\idjl-deps\vcpkg\packages
+        RMDIR /Q/S C:\idjl-deps\vcpkg\downloads
 
     - name: Install setup scripts    
       shell: bash
       run: |
-        mkdir /c/idjl/scripts
-        cp scripts/setup-vcpkg.bat /c/idjl/scripts
-        cp scripts/setup-deps.bat /c/idjl/scripts
-        cp scripts/setup-vcpkg.sh /c/idjl/scripts
-        cp scripts/setup-deps.sh /c/idjl/scripts
-        cp scripts/addPathsToUserEnvVariables-vcpkg.ps1 /c/idjl/scripts
-        cp scripts/addPathsToUserEnvVariables-deps.ps1 /c/idjl/scripts
-        cp scripts/removePathsFromUserEnvVariables-vcpkg.ps1 /c/idjl/scripts
-        cp scripts/removePathsFromUserEnvVariables-deps.ps1 /c/idjl/scripts
+        mkdir /c/idjl-deps/scripts
+        cp scripts/setup-vcpkg.bat /c/idjl-deps/scripts
+        cp scripts/setup-deps.bat /c/idjl-deps/scripts
+        cp scripts/setup-vcpkg.sh /c/idjl-deps/scripts
+        cp scripts/setup-deps.sh /c/idjl-deps/scripts
+        cp scripts/addPathsToUserEnvVariables-vcpkg.ps1 /c/idjl-deps/scripts
+        cp scripts/addPathsToUserEnvVariables-deps.ps1 /c/idjl-deps/scripts
+        cp scripts/removePathsFromUserEnvVariables-vcpkg.ps1 /c/idjl-deps/scripts
+        cp scripts/removePathsFromUserEnvVariables-deps.ps1 /c/idjl-deps/scripts
 
         
     - uses: actions/upload-artifact@v1
       with:
         name: vcpkg-idjl
-        path: C:/idjl
+        path: C:/idjl-deps
         
     - name: Prepare release file
       if: github.event_name == 'release'
       shell: cmd 
       run: |
-        7z a vcpkg-idjl.zip C:\idjl
+        7z a vcpkg-idjl.zip C:\idjl-deps
         
     - name: Upload Release Asset
       if: github.event_name == 'release'
@@ -105,7 +105,7 @@ jobs:
     - uses: actions/download-artifact@v1
       with:
         name: vcpkg-idjl
-        path: C:/idjl
+        path: C:/idjl-deps
 
     - name: Check free space 
       shell: bash 
@@ -117,7 +117,7 @@ jobs:
       run: |
         # Install dependencies for gazebo11 and related ignition dependencies (listed in https://github.com/ignition-tooling/gazebodistro/blob/master/gazebo11.yaml)         
         # gts is not present due to https://github.com/microsoft/vcpkg/issues/10422, and its dependency glib is present instead
-        C:/idjl/vcpkg/vcpkg.exe --overlay-ports=C:/idjl/robotology-vcpkg-binary-ports install --triplet x64-windows boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage glib libyaml libzip jsoncpp ogre protobuf qt5-base[latest] qwt sqlite3[core,tool] tbb tinyxml tinyxml2 urdfdom zeromq
+        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-binary-ports install --triplet x64-windows boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage glib libyaml libzip jsoncpp ogre protobuf qt5-base[latest] qwt sqlite3[core,tool] tbb tinyxml tinyxml2 urdfdom zeromq
         
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
     # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 
@@ -125,14 +125,14 @@ jobs:
     - name: Cleanup vcpkg temporary directories
       shell: cmd 
       run: |
-        RMDIR /Q/S C:\idjl\vcpkg\buildtrees
-        RMDIR /Q/S C:\idjl\vcpkg\packages
-        RMDIR /Q/S C:\idjl\vcpkg\downloads
+        RMDIR /Q/S C:\idjl-deps\vcpkg\buildtrees
+        RMDIR /Q/S C:\idjl-deps\vcpkg\packages
+        RMDIR /Q/S C:\idjl-deps\vcpkg\downloads
         
     - uses: actions/upload-artifact@v1
       with:
         name: vcpkg-idjl-with-gazebo-deps
-        path: C:/idjl
+        path: C:/idjl-deps
 
   build-with-gazebo:
     runs-on: windows-2019
@@ -144,7 +144,7 @@ jobs:
     - uses: actions/download-artifact@v1
       with:
         name: vcpkg-idjl-with-gazebo-deps
-        path: C:/idjl
+        path: C:/idjl-deps
     
     - name: Check free space 
       shell: bash 
@@ -160,36 +160,37 @@ jobs:
     - name: Download Gazebo and related libraries
       shell: bash
       run: |
-        mkdir C:/idjl/gazebo
-        cd C:/idjl/gazebo
+        mkdir C:/idjl-deps/gazebo
+        cd C:/idjl-deps/gazebo
         mkdir src
         vcs import src < ${GITHUB_WORKSPACE}/gazebo-repos.yaml
         
     - name: Build Gazebo and related libraries
       shell: bash
       run: |
-        cd C:/idjl/gazebo
+        cd C:/idjl-deps/gazebo
         colcon build --merge-install --cmake-args -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/idjl/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_TESTING:BOOL=OFF        
     # Remove temporary files
-    - name: Cleanup vcpkg temporary directories
+    - name: Cleanup colcon temporary directories
       shell: cmd 
       run: |
-        RMDIR /Q/S C:\idjl\gazebo\build
-        RMDIR /Q/S C:\idjl\gazebo\src
-        
+        RMDIR /Q/S C:\idjl-deps\gazebo\build
+        RMDIR /Q/S C:\idjl-deps\gazebo\src
+        RMDIR /Q/S C:\idjl-deps\gazebo\log
+
     - name: Install setup scripts    
       shell: bash
       run: |
-        cp scripts/setup-gazebo.bat /c/idjl/scripts
-        cp scripts/setup-gazebo.sh /c/idjl/scripts
-        cp scripts/addPathsToUserEnvVariables-gazebo.ps1 /c/idjl/scripts
-        cp scripts/removePathsFromUserEnvVariables-gazebo.ps1 /c/idjl/scripts
+        cp scripts/setup-gazebo.bat /c/idjl-deps/scripts
+        cp scripts/setup-gazebo.sh /c/idjl-deps/scripts
+        cp scripts/addPathsToUserEnvVariables-gazebo.ps1 /c/idjl-deps/scripts
+        cp scripts/removePathsFromUserEnvVariables-gazebo.ps1 /c/idjl-deps/scripts
         
     - name: Prepare release file
       if: github.event_name == 'release'
       shell: cmd 
       run: |
-        7z a vcpkg-idjl-with-gazebo.zip C:\idjl
+        7z a vcpkg-idjl-with-gazebo.zip C:\idjl-deps
         
     - name: Upload Release Asset
       if: github.event_name == 'release'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,7 +170,7 @@ jobs:
       shell: bash
       run: |
         cd C:/idjl-deps/gazebo
-        colcon build --merge-install --cmake-args -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/idjl/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_TESTING:BOOL=OFF        
+        colcon build --merge-install --cmake-args -G "Visual Studio 16 2019" -A x64 -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/idjl-deps/vcpkg/scripts/buildsystems/vcpkg.cmake -DBUILD_TESTING:BOOL=OFF        
     # Remove temporary files
     - name: Cleanup colcon temporary directories
       shell: cmd 

--- a/gazebo-repos.yaml
+++ b/gazebo-repos.yaml
@@ -2,7 +2,11 @@ repositories:
   gazebo:
     type: git
     url: https://github.com/traversaro/gazebo
-    version: 4ada2574f0735f6fdc933b6bc7e104b00e50e25e
+    # Commit from https://github.com/traversaro/gazebo/tree/fix-vcpkg-gha
+    # With backport of:
+    #  * https://github.com/osrf/gazebo/pull/2758
+    #  * https://github.com/osrf/gazebo/pull/2719
+    version: bc4c1714975433c39acda779d19a2e284ed01fc4
   gts:
     type: git
     url: https://github.com/finetjul/gts
@@ -34,4 +38,4 @@ repositories:
   sdformat:
     type: git
     url: https://github.com/osrf/sdformat
-    version: f7dcdd74fb900e79d5d12db4e022f6e9c83831a1
+    version: b6f73d9fe0e55c9933b1d369dda2771e14ec6ef9


### PR DESCRIPTION
* Update to recent version of vcpkg (https://github.com/microsoft/vcpkg/commit/250e35a961f6faea691e2266613e671a61bb3ab6)
* Move the installation directory to `C:\idjl-deps` to better compatibility with how it is used
* Install also `libpcap` port instead of unmantained `winpcap` library (see https://github.com/microsoft/vcpkg/pull/10731 and https://github.com/microsoft/vcpkg/issues/10730)