### PR TITLE
Bump vcpkg tag and add qt5 dependencies for YARP

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         cd C:/idjl-deps
         git clone https://github.com/Microsoft/vcpkg
         cd vcpkg
-        git checkout 70f192e073dd9e5ed503fc1e86d8a54e2fbaceb4
+        git checkout ac2ddd5f059b56b6e0b9fc0c73bd4feccad539ff
         C:/idjl-deps/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology/robotology-vcpkg-ports C:/idjl-deps/robotology-vcpkg-ports
         cd C:/idjl-deps/robotology-vcpkg-ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
       shell: bash
       run: |
         # Install dependencies for gazebo11 and related ignition dependencies (listed in https://github.com/ignition-tooling/gazebodistro/blob/master/gazebo11.yaml)         
-        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-ports install --triplet x64-windows boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage gts libyaml libzip jsoncpp ogre protobuf qt5-base[latest] qwt sqlite3[core,tool] tbb tinyxml tinyxml2 urdfdom zeromq
+        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-ports install --triplet x64-windows boost-asio boost-any boost-date-time boost-filesystem boost-format boost-interprocess boost-iostreams boost-program-options boost-property-tree boost-regex boost-smart-ptr boost-system boost-thread boost-variant boost-uuid bullet3 cppzmq curl dlfcn-win32 freeimage gts libyaml libzip jsoncpp ogre protobuf qt5-base[latest] qt5-declarative qt5-multimedia qt5-quickcontrols qt5-quickcontrols2 qwt sqlite3[core,tool] tbb tinyxml tinyxml2 urdfdom zeromq
         
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
     # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 


### PR DESCRIPTION
To avoid the problem described in https://github.com/robotology/robotology-superbuild-dependencies-vcpkg/issues/34 and to ensure that YARP can compile fine with all its GUIs using `vcpkg-idjl-with-gazebo.zip` .