### PR TITLE
Add spdlog

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
         C:/idjl-deps/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology/robotology-vcpkg-ports C:/idjl-deps/robotology-vcpkg-ports
         cd C:/idjl-deps/robotology-vcpkg-ports
-        git checkout v0.1.1
+        git checkout v0.2.0
         
     - name: Install vcpkg ports
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       shell: bash
       run: |
         # TinyXML is not installed as a workaround for https://github.com/robotology/ycm/pull/296
-        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-ports install --triplet x64-windows ace assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary libpcap protobuf asio pcl yaml-cpp
+        C:/idjl-deps/vcpkg/vcpkg.exe --overlay-ports=C:/idjl-deps/robotology-vcpkg-ports install --triplet x64-windows ace assimp eigen3 libxml2 eigen3 matio ensenso-binary ipopt-binary libpcap protobuf asio pcl yaml-cpp spdlog
 
     # Remove temporary files https://github.com/Microsoft/vcpkg/blob/master/docs/about/faq.md#how-can-i-remove-temporary-files
     # For some reason doing using git bash to do rm -rf fails for icu's port buildtrees, probably for the use of msys2 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
         cd C:/idjl-deps
         git clone https://github.com/Microsoft/vcpkg
         cd vcpkg
-        git checkout ac2ddd5f059b56b6e0b9fc0c73bd4feccad539ff
+        git checkout 2022.07.25
         C:/idjl-deps/vcpkg/bootstrap-vcpkg.sh
         git clone https://github.com/robotology/robotology-vcpkg-ports C:/idjl-deps/robotology-vcpkg-ports
         cd C:/idjl-deps/robotology-vcpkg-ports

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
   
     # Workaround for https://github.community/t5/GitHub-Actions/Windows-tests-worked-yesterday-broken-today/td-p/43574
     - name: Override bash shell PATH (windows-latest)
-      run: echo "::add-path::C:\Program Files\Git\bin"
+      run: echo "C:\Program Files\Git\bin" >> $GITHUB_PATH
     
     - name: Download custom vcpkg and additional ports 
       shell: bash

--- a/gazebo-repos.yaml
+++ b/gazebo-repos.yaml
@@ -1,33 +1,33 @@
 repositories:
   gazebo:
     type: git
-    url: https://github.com/osrf/gazebo
-    version: gazebo11_11.2.0
+    url: https://github.com/gazebosim/gazebo-classic
+    version: gazebo11_11.12.0
   ign-cmake:
     type: git
-    url: https://github.com/ignitionrobotics/ign-cmake
-    version: ignition-cmake2_2.5.0
+    url: https://github.com/gazebosim/gz-cmake
+    version: ignition-cmake2_2.16.0
   ign-common:
     type: git
-    url: https://github.com/ignitionrobotics/ign-common
-    version: ignition-common3_3.6.1
+    url: https://github.com/gazebosim/gz-common
+    version: ignition-common3_3.15.1
   ign-fuel-tools:
     type: git
-    url: https://github.com/ignitionrobotics/ign-fuel-tools
-    version: ignition-fuel-tools4_4.2.1
+    url: https://github.com/gazebosim/gz-fuel-tools
+    version: ignition-fuel-tools4_4.6.0
   ign-math:
     type: git
-    url: https://github.com/ignitionrobotics/ign-math
-    version: ignition-math6_6.6.0
+    url: https://github.com/gazebosim/gz-math
+    version: ignition-math6_6.13.0
   ign-msgs:
     type: git
-    url: https://github.com/ignitionrobotics/ign-msgs
-    version: ignition-msgs5_5.3.0
+    url: https://github.com/gazebosim/gz-msgs
+    version: ignition-msgs5_5.11.0
   ign-transport:
     type: git
-    url: https://github.com/ignitionrobotics/ign-transport
-    version: ignition-transport8_8.1.0
+    url: https://github.com/gazebosim/gz-transport
+    version: ignition-transport8_8.4.0
   sdformat:
     type: git
-    url: https://github.com/osrf/sdformat
-    version: sdformat9_9.3.0
+    url: https://github.com/gazebosim/sdformat
+    version: sdformat9_9.9.1


### PR DESCRIPTION
I added spdlog as it will be soon needed. Furthremore, I updated the used vcpkg and `robotology-vcpkg-ports` versions, as they dated back to 2020 and now they were not working anymore for the use of download files, that do not exists anymore.